### PR TITLE
Added #if around definitions of x25519 macros for selection of Cortex-M0 versions.

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -14,11 +14,15 @@
 #define wireguard_blake2s(out,outlen,key,keylen,in,inlen) blake2s(out,outlen,key,keylen,in,inlen)
 
 // X25519 IMPLEMENTATION
+#if WG_LWIP_USE_CORTEX_M0_CRYPTO
+// Use the Cortex-M0 assembly implementation for X25519
+#include "crypto/cortex/scalarmult.h"
+#define wireguard_x25519(a,b,c)	crypto_scalarmult_curve25519(a,b,c)
+#else
+// Use the refence C implementation for X25519
 #include "crypto/refc/x25519.h"
 #define wireguard_x25519(a,b,c)	x25519(a,b,c,1)
-
-//#include "crypto/cortex/scalarmult.h"
-//#define wireguard_x25519(a,b,c)	crypto_scalarmult_curve25519(a,b,c)
+#endif
 
 // CHACHA20POLY1305 IMPLEMENTATION
 #include "crypto/refc/chacha20poly1305.h"


### PR DESCRIPTION
Allows selection of the Cortex assembly implementation in a project without the need to edit crypto.h itself. This should make it easier to incorporate wireguard-lwip into a larger SDK, as a submodule.

This is my first GitHub pull request, so please forgive (or correct) any errors of form or etiquette.