### PR TITLE
Fix: Cryptokey routing should check source IP instead of destination IP

### DIFF
--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -311,7 +311,7 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 							// Also check packet length!
 #if LWIP_IPV4
 							if (IPH_V(iphdr) == 4) {
-								ip_addr_copy_from_ip4(dest, iphdr->dest);
+								ip_addr_copy_from_ip4(dest, iphdr->src);
 								for (x=0; x < WIREGUARD_MAX_SRC_IPS; x++) {
 									if (peer->allowed_source_ips[x].valid) {
 										if (ip_addr_netcmp(&dest, &peer->allowed_source_ips[x].ip, &peer->allowed_source_ips[x].mask)) {

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -254,8 +254,8 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 	size_t src_len;
 	struct pbuf *pbuf;
 	struct ip_hdr *iphdr;
-	ip_addr_t dest;
-	bool dest_ok = false;
+	ip_addr_t src_ip;
+	bool src_ok = false;
 	int x;
 	uint32_t now;
 	uint16_t header_len = 0xFFFF;
@@ -311,11 +311,11 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 							// Also check packet length!
 #if LWIP_IPV4
 							if (IPH_V(iphdr) == 4) {
-								ip_addr_copy_from_ip4(dest, iphdr->src);
+								ip_addr_copy_from_ip4(src_ip, iphdr->src);
 								for (x=0; x < WIREGUARD_MAX_SRC_IPS; x++) {
 									if (peer->allowed_source_ips[x].valid) {
-										if (ip_addr_netcmp(&dest, &peer->allowed_source_ips[x].ip, &peer->allowed_source_ips[x].mask)) {
-											dest_ok = true;
+										if (ip_addr_netcmp(&src_ip, &peer->allowed_source_ips[x].ip, &peer->allowed_source_ips[x].mask)) {
+											src_ok = true;
 											header_len = PP_NTOHS(IPH_LEN(iphdr));
 											break;
 										}
@@ -327,13 +327,13 @@ static void wireguardif_process_data_message(struct wireguard_device *device, st
 							if (IPH_V(iphdr) == 6) {
 								// TODO: IPV6 support for route filtering
 								header_len = PP_NTOHS(IPH_LEN(iphdr));
-								dest_ok = true;
+								src_ok = true;
 							}
 #endif /* LWIP_IPV6 */
 							if (header_len <= pbuf->tot_len) {
 
 								// 5. If the plaintext packet has not been dropped, it is inserted into the receive queue of the wg0 interface.
-								if (dest_ok) {
+								if (src_ok) {
 									// Send packet to be process by LWIP
 									ip_input(pbuf, device->netif);
 									// pbuf is owned by IP layer now


### PR DESCRIPTION
The inbound cryptokey routing check in `wireguardif.c` reads `iphdr->dest` (the destination address of the inner packet) instead of `iphdr->src` (the source address).
This means that any peer can inject inner packets with a spoofed source IP.

https://github.com/smartalock/wireguard-lwip/blob/0c44df308984abfb9c9df628002cdf8154c55506/src/wireguardif.c#L314-L320