### PR TITLE
Fix unaligned memory access crash in x25519_core() on ARMv6-M

### DIFF
--- a/src/crypto/refc/x25519.c
+++ b/src/crypto/refc/x25519.c
@@ -233,7 +233,10 @@ static void x25519_core(fe xs[5], const uint8_t scalar[X25519_BYTES], const uint
 #if X25519_MEMCPY_PARAMS
     fe x1i;
     swapin(x1i,x1);
-    x1 = (const uint8_t *)x1;
+    // Point at the aligned copy (x1i), not the original x1 -- using x1
+    // directly causes an unaligned word read that faults on strict-
+    // alignment targets (e.g. Cortex-M0+/ARMv6-M).
+    x1 = (const uint8_t *)x1i;
 #endif
     limb_t swap = 0;
     limb_t *x2 = xs[0],*x3=xs[2],*z3=xs[3];

--- a/src/crypto/refc/x25519.c
+++ b/src/crypto/refc/x25519.c
@@ -233,9 +233,7 @@ static void x25519_core(fe xs[5], const uint8_t scalar[X25519_BYTES], const uint
 #if X25519_MEMCPY_PARAMS
     fe x1i;
     swapin(x1i,x1);
-    // Point at the aligned copy (x1i), not the original x1 -- using x1
-    // directly causes an unaligned word read that faults on strict-
-    // alignment targets (e.g. Cortex-M0+/ARMv6-M).
+    // Note: Fixed typo from upstream implementation to point at aligned memory - https://github.com/MarcusGarfunkel
     x1 = (const uint8_t *)x1i;
 #endif
     limb_t swap = 0;


### PR DESCRIPTION
x1 was reassigned to itself instead of the alignment-safe copy x1i, defeating X25519_MEMCPY_PARAMS's whole purpose. Later code (ladder_part2 -> mul1) reads through the original, potentially- misaligned caller buffer as 4-byte words -- fatal on Cortex-M0+/M0 (ARMv6-M), which has no hardware support for unaligned multi-word loads (unlike M3/M4/M7, where this bug is silently harmless).

Hardware-reproduced on RP2040 (Pico W, via the arduino-wireguard-pico-w port that vendors this file): wireguard_generate_public_key()'s x25519(pubkey, privkey, basepoint) call HardFaults immediately, every time, because `basepoint` (a static const uint8_t[32]) lands at a non-4-byte-aligned flash address. Confirmed via live OpenOCD/gdb: breakpoint on the HardFault vector shows the faulting pointer at 0x100a57eb (& 3 == 3), resolving to the `basepoint` symbol.